### PR TITLE
Null parameter fix into the HttpPushRgb._buildRgbRequest

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,6 +547,13 @@ HttpPushRgb.prototype = {
         var rgb = convert.hsv.rgb([this.cache.hue, this.cache.saturation, this.cache.brightness]);
         var xyz = convert.rgb.xyz(rgb);
         var hex = convert.rgb.hex(rgb);
+
+        if(xyz == null || xyz.size == 0){
+           this.log.warn("Can't read the brightness property! Ignoring the request");
+           return {url: '', body: ''};
+        }
+
+
         var xy = {
             x: (xyz[0] / 100 / (xyz[0] / 100 + xyz[1] / 100 + xyz[2] / 100)).toFixed(4),
             y: (xyz[1] / 100 / (xyz[0] / 100 + xyz[1] / 100 + xyz[2] / 100)).toFixed(4)


### PR DESCRIPTION
Ignoring the request in the case of the brightness is 0. This bug is happening with iOS home app:

 TypeError: Cannot read property '0' of undefined
    at HttpPushRgb._buildRgbRequest (/usr/local/lib/node_modules/homebridge-http-rgb-push/index.js:551:20)
    at HttpPushRgb._setRGB (/usr/local/lib/node_modules/homebridge-http-rgb-push/index.js:535:31)
    at HttpPushRgb.setBrightness (/usr/local/lib/node_modules/homebridge-http-rgb-push/index.js:420:18)
    at Brightness.emit (events.js:315:20)
    at Brightness.EventEmitter.emit (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/EventEmitter.ts:42:22)
    at Brightness.Characteristic._this.setValue (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:651:12)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Accessory.ts:1437:24
    at Array.forEach (<anonymous>)
    at Bridge.Accessory._this._handleSetCharacteristics (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Accessory.ts:1279:10)
    at HAPServer.emit (events.js:315:20)