### PR TITLE
use HSV for reading back RGB rather than HSL

### DIFF
--- a/index.js
+++ b/index.js
@@ -391,7 +391,7 @@ HttpPushRgb.prototype = {
                 this._httpRequest(url, '', 'GET', function(error, response, responseBody) {
                     if (!this._handleHttpErrorResponse('getBrightness()', error, response, responseBody, callback)) {
                         var rgb = responseBody;
-                        var levels = this._rgbToHsl(
+			var levels = convert.rgb.hsv(
                             parseInt(rgb.substr(0,2),16),
                             parseInt(rgb.substr(2,2),16),
                             parseInt(rgb.substr(4,2),16)
@@ -425,7 +425,7 @@ HttpPushRgb.prototype = {
         this.log('Caching Brightness as %s ...', level);
         this.cache.brightness = level;
 
-        // If achromatic or color.brightness is false, update brightness, otherwise, update HSL as RGB
+        // If achromatic or color.brightness is false, update brightness, otherwise, update HSV as RGB
         if (!this.color || !this.color.brightness) {
             var calculatedLevel = Math.ceil(this.brightness.max / 100 * level);
 
@@ -460,7 +460,7 @@ HttpPushRgb.prototype = {
         this._httpRequest(url, '', 'GET', function(error, response, responseBody) {
             if (!this._handleHttpErrorResponse('getHue()', error, response, responseBody, callback)) {
                 var rgb = responseBody;
-                var levels = this._rgbToHsl(
+		var levels = convert.rgb.hsv(
                     parseInt(rgb.substr(0,2),16),
                     parseInt(rgb.substr(2,2),16),
                     parseInt(rgb.substr(4,2),16)
@@ -512,7 +512,7 @@ HttpPushRgb.prototype = {
         this._httpRequest(url, '', 'GET', function(error, response, responseBody) {
             if (!this._handleHttpErrorResponse('getSaturation()', error, response, responseBody, callback)) {
                 var rgb = responseBody;
-                var levels = this._rgbToHsl(
+		var levels = convert.rgb.hsv(
                     parseInt(rgb.substr(0,2),16),
                     parseInt(rgb.substr(2,2),16),
                     parseInt(rgb.substr(4,2),16)
@@ -647,43 +647,6 @@ HttpPushRgb.prototype = {
       }
       return errorOccurred;
    },
-
-    /**
-     * Converts an RGB color value to HSL. Conversion formula
-     * adapted from http://en.wikipedia.org/wiki/HSL_color_space.
-     * Assumes r, g, and b are in [0..255] and
-     * returns h in [0..360], and s and l in [0..100].
-     *
-     * @param   {Number}  r       The red color value
-     * @param   {Number}  g       The green color value
-     * @param   {Number}  b       The blue color value
-     * @return  {Array}           The HSL representation
-     */
-    _rgbToHsl: function(r, g, b){
-        r /= 255;
-        g /= 255;
-        b /= 255;
-        var max = Math.max(r, g, b), min = Math.min(r, g, b);
-        var h, s, l = (max + min) / 2;
-
-        if(max == min){
-            h = s = 0; // achromatic
-        }else{
-            var d = max - min;
-            s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-            switch(max){
-                case r: h = (g - b) / d + (g < b ? 6 : 0); break;
-                case g: h = (b - r) / d + 2; break;
-                case b: h = (r - g) / d + 4; break;
-            }
-            h /= 6;
-        }
-
-        h *= 360; // return degrees [0..360]
-        s *= 100; // return percent [0..100]
-        l *= 100; // return percent [0..100]
-        return [parseInt(h), parseInt(s), parseInt(l)];
-    },
 
     /**
      * Converts a decimal number into a hexidecimal string, with optional


### PR DESCRIPTION
The plugin currently converts HomeKit's HSV to RGB when setting the light, but when reading it back it uses HSL. This causes round trip errors.

For instance, setting hue 120, saturation 100, brightness 100 from HomeKit converts to RGB 00ff00. But on read, using HSL, the brightness drops to 50% ( (max - min) / 2).

This pull request uses HSV for read conversions instead, which correctly converts the brightness back to 100%.